### PR TITLE
Delete relationships manually before deleting user objects

### DIFF
--- a/mepp/api/models/user.py
+++ b/mepp/api/models/user.py
@@ -123,6 +123,13 @@ class User(AbstractUser, Archivable, Searchable):
             active=True,
         ).first()
 
+    def delete(self, using=None, keep_parents=False):
+        # Delete relationship with treatment plans manually to avoid
+        # maximum recursions bug
+        self.patient_treatment_plans.all().delete()
+        self.clinician_treatment_plans.all().delete()
+        return super().delete(using=using, keep_parents=keep_parents)
+
     def generate_new_token(self) -> ExpiringToken:
         try:
             token = ExpiringToken.objects.get(user=self, temporary=False)

--- a/src/components/admin/shared/styles/theme.js
+++ b/src/components/admin/shared/styles/theme.js
@@ -126,6 +126,11 @@ export const MeppTheme = merge({}, defaultTheme, {
         }
       }
     },
+    RaBulkActionsToolbar: {
+      topToolbar: {
+        paddingTop: '10px',
+      },
+    },
     MuiDialogActions: {
       root: {
         '& button': {


### PR DESCRIPTION
Django enters in a infinite loop when it tries to deletes on `CASCADE` TreatmentPlan objects. 
This PR closes #6 