### PR TITLE
Upgrade React to 18.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ra-i18n-polyglot": "^3.11.1",
     "ra-language-english": "^3.11.1",
     "ra-language-french": "^3.11.1",
-    "react": "16.13.0",
+    "react": "17.0.2",
     "react-admin": "^3.19.0",
     "react-dom": "npm:@hot-loader/react-dom",
     "react-hook-form": "^7.12.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ra-i18n-polyglot": "^3.11.1",
     "ra-language-english": "^3.11.1",
     "ra-language-french": "^3.11.1",
-    "react": "17.0.2",
+    "react": "18.2.0",
     "react-admin": "^3.19.0",
     "react-dom": "npm:@hot-loader/react-dom",
     "react-hook-form": "^7.12.2",

--- a/src/components/admin/clinicians/ClinicianCreate.js
+++ b/src/components/admin/clinicians/ClinicianCreate.js
@@ -34,7 +34,7 @@ import {
   useNotify,
 } from 'react-admin';
 
-import SimpleFormToolBar from '../shared/toolbars/SimpleFormToolBar';
+import SimpleFormToolBar from '../shared/toolbars/SimpleFormToolbar';
 import {
   validateEmail,
   validateFirstName,

--- a/src/components/admin/clinicians/ClinicianEdit.js
+++ b/src/components/admin/clinicians/ClinicianEdit.js
@@ -35,7 +35,7 @@ import {
   useNotify,
 } from 'react-admin';
 
-import SimpleFormToolBar from '../shared/toolbars/SimpleFormToolBar';
+import SimpleFormToolBar from '../shared/toolbars/SimpleFormToolbar';
 import {
   validateEmail,
   validateFirstName,

--- a/src/components/admin/exercises/ExerciseCreate.js
+++ b/src/components/admin/exercises/ExerciseCreate.js
@@ -49,7 +49,7 @@ import {
 import SubCategoryInput from '@components/admin/exercises/SubCategoryInput';
 import { LANGUAGES } from '../../../locales';
 import {requiredLocalizedField} from '@components/admin/shared/validators';
-import SimpleFormToolBar from '@components/admin/shared/toolbars/SimpleFormToolBar';
+import SimpleFormToolBar from '@components/admin/shared/toolbars/SimpleFormToolbar';
 import {
   preSave
 } from '@components/admin/exercises/callbacks';

--- a/src/components/admin/exercises/ExerciseEdit.js
+++ b/src/components/admin/exercises/ExerciseEdit.js
@@ -38,7 +38,7 @@ import {
   useTranslate,
 } from 'react-admin';
 
-import SimpleFormToolBar from '@components/admin/shared/toolbars/SimpleFormToolBar';
+import SimpleFormToolBar from '@components/admin/shared/toolbars/SimpleFormToolbar';
 import {
   validateCategory,
   validateSubCategory,

--- a/src/components/admin/patients/PatientCreate.js
+++ b/src/components/admin/patients/PatientCreate.js
@@ -33,7 +33,7 @@ import {
   useTranslate,
   useNotify,
 } from 'react-admin';
-import SimpleFormToolBar from '../shared/toolbars/SimpleFormToolBar';
+import SimpleFormToolBar from '../shared/toolbars/SimpleFormToolbar';
 import {
   validateAudio,
   validateClinician,

--- a/src/components/admin/patients/PatientEdit.js
+++ b/src/components/admin/patients/PatientEdit.js
@@ -35,7 +35,7 @@ import {
   useNotify,
 } from 'react-admin';
 
-import SimpleFormToolBar from '@components/admin/shared/toolbars/SimpleFormToolBar';
+import SimpleFormToolBar from '@components/admin/shared/toolbars/SimpleFormToolbar';
 import {
   validateAudio,
   validateClinician,

--- a/src/components/admin/plans/PlanCreate.js
+++ b/src/components/admin/plans/PlanCreate.js
@@ -44,7 +44,7 @@ import { validateNumber } from '@components/admin/shared/validators';
 import IsSystemInput from '@components/admin/plans/IsSystem';
 import ExerciseRow from '@components/admin/plans/ExerciseRow';
 import { LANGUAGES } from '../../../locales';
-import SimpleFormToolBar from '@components/admin/shared/toolbars/SimpleFormToolBar';
+import SimpleFormToolBar from '@components/admin/shared/toolbars/SimpleFormToolbar';
 import {
   useGetCategories,
   useGetSubCategories,

--- a/src/components/admin/plans/PlanEdit.js
+++ b/src/components/admin/plans/PlanEdit.js
@@ -46,7 +46,7 @@ import { LANGUAGES } from "../../../locales";
 import { validateExercises } from '@components/admin/plans/validators';
 import { validateNumber } from '@components/admin/shared/validators';
 
-import SimpleFormToolBar from '@components/admin/shared/toolbars/SimpleFormToolBar';
+import SimpleFormToolBar from '@components/admin/shared/toolbars/SimpleFormToolbar';
 import ExerciseRow from './ExerciseRow';
 import IsSystemInput from '@components/admin/plans/IsSystem';
 import TopToolbar from '@components/admin/shared/toolbars/TopToolbar';

--- a/src/components/exercises/ExerciseProvider.js
+++ b/src/components/exercises/ExerciseProvider.js
@@ -22,7 +22,7 @@
 
 import React, { createContext, useEffect, useState } from 'react';
 
-import { useApi } from '@hooks/useAPI';
+import { useApi } from '@hooks/useApi';
 
 import { RequestEndpoint, RequestMethod } from '@utils/constants';
 import { fetchData } from '@utils/fetch';

--- a/src/components/forms/ForgotPwdForm.jsx
+++ b/src/components/forms/ForgotPwdForm.jsx
@@ -28,7 +28,7 @@ import styled from 'styled-components';
 import { spacings } from '@styles/configs/spacings';
 import { FlexAlignCenter, FlexAlignMiddle } from '@styles/tools';
 
-import { useApi } from '@hooks/useAPI';
+import { useApi } from '@hooks/useApi';
 
 import { RequestEndpoint } from '@utils/constants';
 

--- a/src/components/forms/ProfileForm.jsx
+++ b/src/components/forms/ProfileForm.jsx
@@ -30,7 +30,7 @@ import { spacings } from '@styles/configs/spacings';
 import { FlexAlignCenter } from '@styles/tools';
 import { rem } from '@styles/utils/rem';
 
-import { useApi } from '@hooks/useAPI';
+import { useApi } from '@hooks/useApi';
 
 import { RequestEndpoint } from '@utils/constants';
 

--- a/src/components/forms/ResetPasswordForm.jsx
+++ b/src/components/forms/ResetPasswordForm.jsx
@@ -28,7 +28,7 @@ import styled from 'styled-components';
 import { spacings } from '@styles/configs/spacings';
 import { FlexAlignMiddle, FlexAlignCenter } from '@styles/tools';
 
-import { useApi } from '@hooks/useAPI';
+import { useApi } from '@hooks/useApi';
 
 import { RequestEndpoint } from '@utils/constants';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6929,13 +6929,12 @@ react-transition-group@^4.4.0, react-transition-group@^4.4.1:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react@17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+react@18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
+  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 "readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6929,14 +6929,13 @@ react-transition-group@^4.4.0, react-transition-group@^4.4.1:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react@16.13.0:
-  version "16.13.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.13.0.tgz#d046eabcdf64e457bbeed1e792e235e1b9934cf7"
-  integrity sha512-TSavZz2iSLkq5/oiE7gnFzmURKZMltmi193rm5HEoUDAXpzT9Kzw6oNZnGoai/4+fUnm7FqS5dwgUL34TujcWQ==
+react@17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
+  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
 
 "readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"


### PR DESCRIPTION
This PR upgrades the project's React dependency to v18.2.0. The upgrade appears to have no negative impact on functionality on either the patient side or the admin side. A new warning does appear in the console, however:

`react.development.js:209 Warning: Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:
1. You might have mismatching versions of React and the renderer (such as React DOM)
2. You might be breaking the Rules of Hooks
3. You might have more than one copy of React in the same app
See https://reactjs.org/link/invalid-hook-call for tips about how to debug and fix this problem.`

I believe this is related to the @hot-loader/react-dom dependency, which is [no longer actively maintained](https://github.com/gaearon/react-hot-loader/issues/1808). The solution would likely be to get rid of this dependency and switch to built-in react tooling. 

This also includes some minor changes to the cases of import paths. On my linux system webpack could not resolve those imports due to the mismatch in case between the given path and the actual filename. I decided to leave the filenames as-is and just changed the import paths.