### PR TITLE
Toggle label of "Cancel" button when configuring the effect

### DIFF
--- a/src/components/generics/GUI.jsx
+++ b/src/components/generics/GUI.jsx
@@ -139,6 +139,11 @@ const GUIProvider = ({ children }) => {
       });
       if (response.status === 200) {
         notify('api.success.settings_update', { type: 'success' });
+        identity.mirror_settings = {
+          position,
+          rotation,
+          scale
+        }
       } else {
         notify('api.error.generic', { type: 'error' });
       }
@@ -146,6 +151,32 @@ const GUIProvider = ({ children }) => {
 
     send();
   }, [patch, notify, t]);
+
+  const valuesAreEqual = (a, b) => {
+    return JSON.stringify(a) === JSON.stringify(b);
+  };
+
+  const formUnchanged = () => {
+    if (identity?.mirror_settings && guiRef?.current) {
+      const data = guiRef.current.save();
+      return (
+        valuesAreEqual(
+          data.folders[t('GUI:folders:position')].controllers,
+          identity.mirror_settings.position,
+        ) &&
+        valuesAreEqual(
+          data.folders[t('GUI:folders:rotation')].controllers,
+          identity.mirror_settings.rotation,
+        ) &&
+        valuesAreEqual(
+          data.folders[t('GUI:folders:scale')].controllers,
+          identity.mirror_settings.scale,
+        )
+      );
+    } else {
+      return true;
+    }
+  };
 
   useEffect(() => {
     if (ready) return;
@@ -222,7 +253,7 @@ const GUIProvider = ({ children }) => {
         <Button.Outline label={t('GUI:cta:profile')} onClick={onApplyProfile} />
         <Button.Outline label={t('GUI:cta:default')} onClick={onApplyDefault} />
         <Button.Default
-          label={t('cta:cancel')}
+          label={formUnchanged() ? t('cta:close') : t('cta:cancel')}
           onClick={() => navigate('/intro')}
         />
         <Button.Default label={t('cta:save')} onClick={onSave} />

--- a/src/components/generics/GUI.jsx
+++ b/src/components/generics/GUI.jsx
@@ -142,8 +142,8 @@ const GUIProvider = ({ children }) => {
         identity.mirror_settings = {
           position,
           rotation,
-          scale
-        }
+          scale,
+        };
       } else {
         notify('api.error.generic', { type: 'error' });
       }
@@ -252,11 +252,15 @@ const GUIProvider = ({ children }) => {
       <ButtonWrapper>
         <Button.Outline label={t('GUI:cta:profile')} onClick={onApplyProfile} />
         <Button.Outline label={t('GUI:cta:default')} onClick={onApplyDefault} />
-        <Button.Default
-          label={formUnchanged() ? t('cta:close') : t('cta:cancel')}
+        <Button.Secondary
+          label={t('cta:close')}
           onClick={() => navigate('/intro')}
         />
-        <Button.Default label={t('cta:save')} onClick={onSave} />
+        <Button.Default
+          disabled={formUnchanged() ? true : false}
+          label={t('cta:save')}
+          onClick={onSave}
+        />
       </ButtonWrapper>
       {(loading || identityLoading) && <LoadingCircle opaque />}
     </GUIContext.Provider>

--- a/src/components/generics/GUI.jsx
+++ b/src/components/generics/GUI.jsx
@@ -125,6 +125,12 @@ const GUIProvider = ({ children }) => {
     guiRef.current.load(clone);
   };
 
+  const closeWithoutSaveConfirm = () => {
+    if (window.confirm('Close without saving changes?')) {
+      navigate('/intro');
+    }
+  };
+
   const onSave = useCallback(() => {
     const data = guiRef.current.save();
     const position = data.folders[t('GUI:folders:position')].controllers;
@@ -254,7 +260,9 @@ const GUIProvider = ({ children }) => {
         <Button.Outline label={t('GUI:cta:default')} onClick={onApplyDefault} />
         <Button.Secondary
           label={t('cta:close')}
-          onClick={() => navigate('/intro')}
+          onClick={() => {
+            formUnchanged() ? navigate('/intro') : closeWithoutSaveConfirm();
+          }}
         />
         <Button.Default
           disabled={formUnchanged() ? true : false}

--- a/src/components/generics/GUI.jsx
+++ b/src/components/generics/GUI.jsx
@@ -24,6 +24,7 @@ import React, {
   useRef,
   useEffect,
   useState,
+  useContext,
   useCallback,
   createContext,
 } from 'react';
@@ -40,6 +41,7 @@ import { RequestEndpoint } from '@utils/constants';
 
 import { LoadingCircle } from '@components/generics/LoadingCircle';
 import Button from '@components/generics/buttons/Button';
+import { OverlayContext, ConfirmOverlay } from '@components/overlays';
 
 /**
  * GUI DEFAULTS
@@ -64,6 +66,7 @@ const GUIProvider = ({ children }) => {
   const { t } = useTranslation();
   const notify = useNotify();
   const navigate = useNavigate();
+  const { open, close } = useContext(OverlayContext);
   const { identity, isLoading: identityLoading } = useGetIdentity();
   const { patch, loading } = useApi(RequestEndpoint.SETTINGS);
   const [position, setPosition] = useState({ ...defaultPosition });
@@ -126,9 +129,18 @@ const GUIProvider = ({ children }) => {
   };
 
   const closeWithoutSaveConfirm = () => {
-    if (window.confirm('Close without saving changes?')) {
-      navigate('/intro');
-    }
+    guiRef.current.hide();
+    open(
+      <ConfirmOverlay
+        close={() => {
+          guiRef.current.show();
+          close();
+        }}
+        confirm={() => {
+          navigate('/intro');
+        }}
+      />,
+    );
   };
 
   const onSave = useCallback(() => {
@@ -283,7 +295,7 @@ const ButtonWrapper = styled.div`
   gap: ${spacings.default}px;
   width: 100%;
   bottom: 0;
-  z-index: 800;
+  z-index: 1;
 `;
 
 export { GUIContext };

--- a/src/components/generics/buttons/Button.jsx
+++ b/src/components/generics/buttons/Button.jsx
@@ -22,9 +22,12 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
 
+
+
 import { media } from '@styles/configs/breakpoints';
 import { HoverOrActive } from '@styles/utils/HoverOrActive';
 import { rem } from '@styles/utils/rem';
+
 
 /**
  * BUTTON SIDE LABEL TYPES ALLOWED
@@ -49,6 +52,7 @@ const ButtonFactory = (Button) => {
               'role': 'switch',
             }
           : {})}
+        disabled={props.disabled}
       >
         {label && label}
         {icon && icon}
@@ -126,6 +130,12 @@ const button = css`
       fill: ${({ theme }) => theme.colors.secondary};
     }
   `}
+
+  :disabled {
+    color: #9f9f9f;
+    background-color: #d7d7d7;
+    cursor: default;
+  }
 `;
 
 /**
@@ -133,6 +143,18 @@ const button = css`
  */
 const Default = styled.button`
   ${button}
+`;
+
+/**
+ * Button style components
+ */
+
+const Secondary = styled(Default)`
+  background-color: #666d77;
+
+  ${HoverOrActive`
+    background-color: #939dab;
+  `}
 `;
 
 /**
@@ -246,6 +268,7 @@ const Liner = styled.button`
 export { ButtonSideLabelTypes };
 export default {
   Default: ButtonFactory(Default),
+  Secondary: ButtonFactory(Secondary),
   Outline: ButtonFactory(Outline),
   Transparent: ButtonFactory(Transparent),
   Liner: ButtonFactory(Liner),

--- a/src/components/overlays/ConfirmOverlay.js
+++ b/src/components/overlays/ConfirmOverlay.js
@@ -1,0 +1,74 @@
+/*
+ * MEPP - A web application to guide patients and clinicians in the process of
+ * facial palsy rehabilitation, with the help of the mirror effect and principles
+ * of motor learning
+ * Copyright (C) 2021 MEPP <info@mirroreffectplus.org>
+ *
+ * This file is part of MEPP.
+ *
+ * MEPP is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MEPP is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MEPP.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
+
+import { spacings } from '@styles/configs/spacings';
+import { FlexAlignCenter, FlexAlignMiddle } from '@styles/tools/index';
+
+import { H2 } from '@components/generics/basics/Heading';
+import Button from '@components/generics/buttons/Button';
+
+/**
+ * Confirm Overlay
+ */
+const ConfirmOverlay = (props) => {
+  const { t } = useTranslation();
+  const close = props.close ? props.close : () => {};
+  const confirm = props.confirm ? props.confirm : () => {};
+
+  return (
+    <ContainerWrapper>
+      <Container>
+        <Title
+          dangerouslySetInnerHTML={{ __html: t('GUI:confirm:title') }}
+        ></Title>
+        <NavWrapper>
+          <Button.Default label={t('cta:cancel')} onClick={close} />
+          <Button.Outline label={t('cta:confirm')} onClick={confirm} />
+        </NavWrapper>
+      </Container>
+    </ContainerWrapper>
+  );
+};
+
+const ContainerWrapper = styled(FlexAlignMiddle.Component)`
+  width: 100%;
+  height: calc(100vh - 200px);
+  background-color: ${({ theme }) => `${theme.colors.background}`};
+`;
+
+const Container = styled.div`
+  max-width: 600px;
+  margin: 0 auto;
+`;
+
+const Title = styled(H2)`
+  text-align: center;
+`;
+
+const NavWrapper = styled(FlexAlignCenter.Component)`
+  gap: ${spacings.default}px;
+`;
+
+export { ConfirmOverlay };

--- a/src/components/overlays/index.js
+++ b/src/components/overlays/index.js
@@ -19,12 +19,12 @@
  * You should have received a copy of the GNU General Public License
  * along with MEPP.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 import OverlayProvider, {
   OverlayContext,
 } from '@components/overlays/OverlayProvider';
 
-import SettingsOverlay from '.SettingsOverlay';
+import { ConfirmOverlay } from './ConfirmOverlay';
+import { SettingsOverlay } from './SettingsOverlay';
 
-export { SettingsOverlay };
+export { SettingsOverlay, ConfirmOverlay };
 export { OverlayProvider, OverlayContext };

--- a/src/locales/en/cta.js
+++ b/src/locales/en/cta.js
@@ -45,5 +45,6 @@ export default {
     save: 'Save',
     modify: 'Modify',
     back: 'Back',
+    confirm: 'Ok',
   },
 };

--- a/src/locales/en/cta.js
+++ b/src/locales/en/cta.js
@@ -41,6 +41,7 @@ export default {
     authorize: 'Authorize',
 
     cancel: 'Cancel',
+    close: 'Close',
     save: 'Save',
     modify: 'Modify',
     back: 'Back',

--- a/src/locales/en/index.js
+++ b/src/locales/en/index.js
@@ -62,5 +62,8 @@ export default {
       profile: 'Profile values',
       default: 'Default values',
     },
+    confirm: {
+      title: 'Are you sure you want to exit without saving?',
+    },
   },
 };

--- a/src/locales/fr/cta.js
+++ b/src/locales/fr/cta.js
@@ -40,6 +40,7 @@ export default {
     authorize: 'Autoriser',
 
     cancel: 'Annuler',
+    close: 'Fermer',
     save: 'Sauvegarder',
     modify: 'Modifier',
     back: 'Retour',

--- a/src/locales/fr/cta.js
+++ b/src/locales/fr/cta.js
@@ -44,5 +44,6 @@ export default {
     save: 'Sauvegarder',
     modify: 'Modifier',
     back: 'Retour',
+    confirm: 'Ok',
   },
 };

--- a/src/locales/fr/index.js
+++ b/src/locales/fr/index.js
@@ -69,5 +69,8 @@ export default {
       profile: 'Valeurs du profil',
       default: 'Valeurs par défaut',
     },
+    confirm: {
+      title: 'Voulez-vous vraiment quitter sans enregistrer&nbsp;?',
+    },
   },
 };


### PR DESCRIPTION
This PR fixes issue #47. At the same time, it also changes the handling of identity state so that `identity.mirror_settings` is updated upon a successful save. It is not the most graceful means of doing this. I would have preferred to use the refetch() function from RA's useGetIdentity(), but I could not get this to work and wasn't sure if I should be spending much time on it.

I believe the identity state change fixes an issue that I **think** was impacting the function of the "Profile values" button. My assumption was that the "Profile values" button was intended to reset the mirror settings to their last saved values. For example:

1. My original settings are the same as the default settings. Default value for `position.x` is 0.
2. I open the mirror app and change `position.x` to 1 and press 'Save'.
3. I change `position.x` to 2 without saving.
4. I press the "Profile values" button

I expect that when I press "Profile values" `position.x` should revert back to 1, its last saved value. If I'm correct in this, the button was not working as intended because the identity state was not updated upon pressing save. Instead, `position.x` would revert to 0, the saved value when the mirror app was initially loaded. Please let me know if I misunderstood this.