### PR TITLE
Fix cookie banner floating button and slider behavior

### DIFF
--- a/public/cookie-consent/cookie-banner.js
+++ b/public/cookie-consent/cookie-banner.js
@@ -269,7 +269,12 @@ function applyTranslations() {
   if (acceptBtn) acceptBtn.textContent = trans.acceptButton;
   if (rejectBtn) rejectBtn.textContent = trans.rejectButton;
   if (prefsBtn) prefsBtn.textContent = trans.preferencesButton;
-  if (floatBtn) floatBtn.textContent = trans.footerLink;
+  if (floatBtn) {
+    var floatSpan = floatBtn.querySelector('span');
+    if (floatSpan) {
+      floatSpan.textContent = trans.footerLink;
+    }
+  }
 
   // Preferences panel
   var prefsTitle = document.getElementById('prefs-title');
@@ -392,12 +397,6 @@ function setupToggleSwitches() {
           }
         });
 
-        // Add click event listener to slider for better UX
-        slider.addEventListener('click', function() {
-          input.checked = !input.checked;
-          input.dispatchEvent(new Event('change'));
-        });
-
         input.dataset.listenerAttached = 'true';
       }
     }
@@ -468,7 +467,9 @@ function updateFloatingButtonIcon(consent) {
 
   // Check if button should show text (preserve text if showText is enabled)
   var shouldShowText = true;
-  var text = "Cookie Settings";
+  var lang = detectLanguage();
+  var trans = TRANSLATIONS[lang] || TRANSLATIONS.en;
+  var text = trans.footerLink;
   var hasLogo = true;
   var logoUrl = "https://mirroreffectplus.org/apple-touch-icon.png";
   var shape = "pill";


### PR DESCRIPTION
## Summary
- Fix floating button text update to target inner `<span>` element instead of overwriting entire button content (was breaking the button icon/layout)
- Remove duplicate click event listener on toggle slider that caused double-toggle bug
- Use translated text for floating button label instead of hardcoded "Cookie Settings"

## Test plan
- [ ] Verify the floating cookie button displays correctly with icon and translated text
- [ ] Toggle cookie preferences sliders — each click should toggle once, not twice
- [ ] Switch language and verify the floating button text updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)