### PR TITLE
feat: update privacy policy for Loi 25 compliance (6 languages)

### DIFF
--- a/src/pages/privacy/de.js
+++ b/src/pages/privacy/de.js
@@ -130,7 +130,42 @@ const LocalizedPrivacy = () => {
         laden wir Sie ein, uns zu kontaktieren.
       </P>
 
-      <H5>3. TECHNOLOGIEN</H5>
+      <H6>2.4 Recht auf Löschung und Anonymisierung</H6>
+
+      <P>
+        Sie können die Löschung Ihres Kontos und die Anonymisierung Ihrer
+        personenbezogenen Daten beantragen. Ihre Identifikationsdaten (Name,
+        E-Mail) werden unwiderruflich anonymisiert. Sitzungs- und Übungsdaten
+        werden in entidentifizierter Form für wissenschaftliche
+        Forschungszwecke aufbewahrt. Um dieses Recht auszuüben, wenden Sie sich
+        an Ihren Kliniker oder unseren Datenschutzbeauftragten unter den unten
+        angegebenen Kontaktdaten.
+      </P>
+
+      <H6>2.5 Recht auf Datenübertragbarkeit</H6>
+
+      <P>
+        Sie können beantragen, Ihre personenbezogenen Daten in einem
+        strukturierten und gängigen Format zu erhalten. Um dieses Recht
+        auszuüben, kontaktieren Sie uns unter den unten angegebenen
+        Kontaktdaten.
+      </P>
+
+      <H6>2.6 Detaillierte Zwecke</H6>
+
+      <P>
+        Personenbezogene Daten werden für folgende Zwecke erhoben und
+        verarbeitet:
+      </P>
+      <UL>
+        <LI>Erstellung und Verwaltung Ihres Kontos;</LI>
+        <LI>Personalisierung Ihrer Rehabilitationsübungen;</LI>
+        <LI>Überwachung Ihres Fortschritts durch Ihren Kliniker;</LI>
+        <LI>wissenschaftliche Forschung in entidentifizierter Form;</LI>
+        <LI>Verbesserung von MEPP und der Rehabilitationsansätze.</LI>
+      </UL>
+
+      <H5>3. TECHNOLOGIEN UND COOKIES</H5>
 
       <P>
         Bestimmte MEPP-Technologien sind mit allgemeinen Informationen über Ihr
@@ -138,6 +173,13 @@ const LocalizedPrivacy = () => {
         gewährleisten. Diese Technologien sind erforderlich, damit MEPP
         ordnungsgemäß funktioniert, und werden automatisch gelöscht, wenn Sie
         MEPP deinstallieren. Zögern Sie nicht, uns bei Fragen zu kontaktieren.
+      </P>
+
+      <P>
+        MEPP verwendet ausschließlich für den Betrieb der Anwendung notwendige
+        Cookies (Sitzung, Authentifizierung). Es werden keine Tracking- oder
+        Werbe-Cookies verwendet. Sie können Ihre Cookie-Einstellungen über das
+        bei Ihrem ersten Besuch angezeigte Zustimmungsbanner verwalten.
       </P>
 
       <H5>4. SICHERHEITSMASSNAHMEN</H5>
@@ -157,14 +199,26 @@ const LocalizedPrivacy = () => {
         unterliegt.
       </P>
 
-      <H5>5. FRAGEN</H5>
+      <H5>5. RECHTSRAHMEN UND BESCHWERDEN</H5>
+
+      <P>
+        MEPP entspricht dem Gesetz zum Schutz personenbezogener Daten im
+        privaten Sektor (Gesetz 25) von Quebec. Wenn Sie der Meinung sind, dass
+        Ihre Rechte nicht respektiert werden, können Sie eine Beschwerde bei der
+        Commission d&apos;accès à l&apos;information du Québec (CAI) einreichen:{' '}
+        <a href="https://www.cai.gouv.qc.ca" target="_blank" rel="noopener noreferrer">
+          www.cai.gouv.qc.ca
+        </a>.
+      </P>
+
+      <H5>6. FRAGEN</H5>
 
       <P>
         Sie können uns kontaktieren, wenn Sie Fragen zu unseren
         Datenschutzpraktiken haben.
       </P>
 
-      <H5>6. HYPERLINKS</H5>
+      <H5>7. HYPERLINKS</H5>
 
       <P>
         MEPP und dessen Inhalte enthalten Links zu anderen Ressourcen. Diese
@@ -184,9 +238,9 @@ const LocalizedPrivacy = () => {
         konsultieren.
       </P>
 
-      <H5>7. WEITERE BEDINGUNGEN</H5>
+      <H5>8. WEITERE BEDINGUNGEN</H5>
 
-      <H6>7.1 Gesamte Vereinbarung</H6>
+      <H6>8.1 Gesamte Vereinbarung</H6>
 
       <P>
         Diese Datenschutzrichtlinie stellt zusammen mit den Nutzungsbedingungen
@@ -195,7 +249,7 @@ const LocalizedPrivacy = () => {
         diese Richtlinie auf der MEPP-Website zum Download verfügbar sind.
       </P>
 
-      <H6>7.2 Änderungen</H6>
+      <H6>8.2 Änderungen</H6>
 
       <P>
         Wir können diese Datenschutzrichtlinie ändern. Diese Änderungen werden
@@ -206,7 +260,7 @@ const LocalizedPrivacy = () => {
         Anwendung vor Inkrafttreten dieser Änderungen deinstallieren.
       </P>
 
-      <H6>7.3 Anwendbares Recht und Streitigkeiten</H6>
+      <H6>8.3 Anwendbares Recht und Streitigkeiten</H6>
 
       <P>
         MEPP, dessen Inhalte und diese Datenschutzrichtlinie unterliegen den in
@@ -216,7 +270,14 @@ const LocalizedPrivacy = () => {
         zuständig sind, um diese zu lösen.
       </P>
 
-      <H6>7.4 Kommunikation</H6>
+      <H6>8.4 Datenschutzbeauftragter</H6>
+
+      <P>
+        Bei Fragen zum Schutz Ihrer personenbezogenen Daten oder zur Ausübung
+        Ihrer Rechte können Sie unseren Datenschutzbeauftragten kontaktieren:
+      </P>
+
+      <H6>8.5 Kommunikation</H6>
 
       <P>Sie können uns unter den folgenden Angaben kontaktieren:</P>
 

--- a/src/pages/privacy/en.js
+++ b/src/pages/privacy/en.js
@@ -123,7 +123,40 @@ const LocalizedPrivacy = () => {
         your profile. Otherwise, we invite you to contact us.
       </P>
 
-      <H5>3. TECHNOLOGIES</H5>
+      <H6>2.4 Right to Deletion and Anonymization</H6>
+
+      <P>
+        You may request the deletion of your account and the anonymization of
+        your personal information. Your identifying data (name, email) will be
+        irreversibly anonymized. Session and exercise data will be retained in
+        de-identified form for scientific research purposes. To exercise this
+        right, contact your clinician or our privacy officer at the contact
+        details provided below.
+      </P>
+
+      <H6>2.5 Right to Data Portability</H6>
+
+      <P>
+        You may request to receive your personal information in a structured
+        and commonly used format. To exercise this right, contact us at the
+        details provided below.
+      </P>
+
+      <H6>2.6 Detailed Purposes</H6>
+
+      <P>
+        Personal information is collected and processed for the following
+        purposes:
+      </P>
+      <UL>
+        <LI>creating and managing your account;</LI>
+        <LI>personalizing your rehabilitation exercises;</LI>
+        <LI>enabling your clinician to monitor your progress;</LI>
+        <LI>scientific research in de-identified form;</LI>
+        <LI>improving MEPP and rehabilitation approaches.</LI>
+      </UL>
+
+      <H5>3. TECHNOLOGIES AND COOKIES</H5>
 
       <P>
         Certain MEPP technologies are linked to general information about your
@@ -131,6 +164,13 @@ const LocalizedPrivacy = () => {
         are required for MEPP to function properly and will be automatically
         deleted if you uninstall MEPP. Do not hesitate to contact us for any
         questions.
+      </P>
+
+      <P>
+        MEPP uses cookies that are strictly necessary for the application to
+        function (session, authentication). No tracking or advertising cookies
+        are used. You can manage your cookie preferences via the consent banner
+        displayed on your first visit.
       </P>
 
       <H5>4. SECURITY MEASURES</H5>
@@ -147,14 +187,26 @@ const LocalizedPrivacy = () => {
         not be subject to data interception or other uncontrollable events.
       </P>
 
-      <H5>5. QUESTIONS</H5>
+      <H5>5. LEGAL FRAMEWORK AND COMPLAINTS</H5>
+
+      <P>
+        MEPP complies with Quebec&apos;s Act respecting the protection of personal
+        information in the private sector (Law 25). If you believe your rights
+        are not being respected, you may file a complaint with the Commission
+        d&apos;accès à l&apos;information du Québec (CAI) at:{' '}
+        <a href="https://www.cai.gouv.qc.ca" target="_blank" rel="noopener noreferrer">
+          www.cai.gouv.qc.ca
+        </a>.
+      </P>
+
+      <H5>6. QUESTIONS</H5>
 
       <P>
         You can contact us if you have any questions regarding our privacy
         practices.
       </P>
 
-      <H5>6. HYPERLINKS</H5>
+      <H5>7. HYPERLINKS</H5>
 
       <P>
         MEPP and its content include links to other resources. These hyperlinks
@@ -172,9 +224,9 @@ const LocalizedPrivacy = () => {
         your decision to consult these hyperlinks.
       </P>
 
-      <H5>7. OTHER TERMS</H5>
+      <H5>8. OTHER TERMS</H5>
 
-      <H6>7.1 Complete Agreement</H6>
+      <H6>8.1 Complete Agreement</H6>
 
       <P>
         This privacy policy constitutes, along with the terms of use, the full
@@ -183,7 +235,7 @@ const LocalizedPrivacy = () => {
         website.
       </P>
 
-      <H6>7.2 Modifications</H6>
+      <H6>8.2 Modifications</H6>
 
       <P>
         We may modify this privacy policy. These changes will be brought to your
@@ -193,7 +245,7 @@ const LocalizedPrivacy = () => {
         application before these changes take effect.
       </P>
 
-      <H6>7.3 Applicable Laws and Disputes</H6>
+      <H6>8.3 Applicable Laws and Disputes</H6>
 
       <P>
         MEPP, its content, and this privacy policy are subject to the laws in
@@ -203,7 +255,14 @@ const LocalizedPrivacy = () => {
         resolve it.
       </P>
 
-      <H6>7.4 Communications</H6>
+      <H6>8.4 Privacy Officer</H6>
+
+      <P>
+        For any questions regarding the protection of your personal information
+        or to exercise your rights, you may contact our privacy officer:
+      </P>
+
+      <H6>8.5 Communications</H6>
 
       <P>You can contact us using the following details:</P>
 

--- a/src/pages/privacy/es.js
+++ b/src/pages/privacy/es.js
@@ -128,7 +128,41 @@ const LocalizedPrivacy = () => {
         contacto con nosotros.
       </P>
 
-      <H5>3. TECNOLOGÍAS</H5>
+      <H6>2.4 Derecho de supresión y anonimización</H6>
+
+      <P>
+        Puede solicitar la eliminación de su cuenta y la anonimización de su
+        información personal. Sus datos de identificación (nombre, correo
+        electrónico) serán anonimizados de forma irreversible. Los datos de
+        sesión y ejercicios se conservarán de forma desidentificada con fines
+        de investigación científica. Para ejercer este derecho, contacte a su
+        clínico o a nuestro responsable de protección de datos en las
+        coordenadas indicadas a continuación.
+      </P>
+
+      <H6>2.5 Derecho a la portabilidad</H6>
+
+      <P>
+        Puede solicitar recibir su información personal en un formato
+        estructurado y de uso común. Para ejercer este derecho, contáctenos
+        en las coordenadas indicadas a continuación.
+      </P>
+
+      <H6>2.6 Finalidades detalladas</H6>
+
+      <P>
+        La información personal se recopila y procesa para las siguientes
+        finalidades:
+      </P>
+      <UL>
+        <LI>la creación y gestión de su cuenta;</LI>
+        <LI>la personalización de sus ejercicios de rehabilitación;</LI>
+        <LI>el seguimiento de su progreso por parte de su clínico;</LI>
+        <LI>la investigación científica en forma desidentificada;</LI>
+        <LI>la mejora de MEPP y de los enfoques de rehabilitación.</LI>
+      </UL>
+
+      <H5>3. TECNOLOGÍAS Y COOKIES</H5>
 
       <P>
         Ciertas tecnologías de MEPP están vinculadas a información general sobre
@@ -136,6 +170,14 @@ const LocalizedPrivacy = () => {
         Estas tecnologías son necesarias para que MEPP funcione correctamente y
         se eliminarán automáticamente si desinstala MEPP. No dude en
         contactarnos si tiene alguna pregunta.
+      </P>
+
+      <P>
+        MEPP utiliza cookies estrictamente necesarias para el funcionamiento de
+        la aplicación (sesión, autenticación). No se utilizan cookies de
+        seguimiento ni publicitarias. Puede gestionar sus preferencias de
+        cookies a través del banner de consentimiento mostrado en su primera
+        visita.
       </P>
 
       <H5>4. MEDIDAS DE SEGURIDAD</H5>
@@ -153,14 +195,26 @@ const LocalizedPrivacy = () => {
         de datos u otros eventos incontrolables.
       </P>
 
-      <H5>5. PREGUNTAS</H5>
+      <H5>5. MARCO JURÍDICO Y QUEJAS</H5>
+
+      <P>
+        MEPP cumple con la Ley de protección de información personal del sector
+        privado (Ley 25) de Quebec. Si considera que sus derechos no están
+        siendo respetados, puede presentar una queja ante la Commission
+        d&apos;accès à l&apos;information du Québec (CAI):{' '}
+        <a href="https://www.cai.gouv.qc.ca" target="_blank" rel="noopener noreferrer">
+          www.cai.gouv.qc.ca
+        </a>.
+      </P>
+
+      <H5>6. PREGUNTAS</H5>
 
       <P>
         Puede ponerse en contacto con nosotros si tiene alguna pregunta sobre
         nuestras prácticas de privacidad.
       </P>
 
-      <H5>6. HIPERVÍNCULOS</H5>
+      <H5>7. HIPERVÍNCULOS</H5>
 
       <P>
         MEPP y su contenido incluyen enlaces a otros recursos. Estos
@@ -179,9 +233,9 @@ const LocalizedPrivacy = () => {
         ellos. Es su decisión consultar estos hipervínculos.
       </P>
 
-      <H5>7. OTROS TÉRMINOS</H5>
+      <H5>8. OTROS TÉRMINOS</H5>
 
-      <H6>7.1 Acuerdo completo</H6>
+      <H6>8.1 Acuerdo completo</H6>
 
       <P>
         Esta política de privacidad constituye, junto con los términos de uso,
@@ -190,7 +244,7 @@ const LocalizedPrivacy = () => {
         disponibles para su descarga en el sitio web de MEPP.
       </P>
 
-      <H6>7.2 Modificaciones</H6>
+      <H6>8.2 Modificaciones</H6>
 
       <P>
         Podemos modificar esta política de privacidad. Estos cambios se le
@@ -200,7 +254,7 @@ const LocalizedPrivacy = () => {
         antes de que estos cambios entren en vigor.
       </P>
 
-      <H6>7.3 Leyes aplicables y disputas</H6>
+      <H6>8.3 Leyes aplicables y disputas</H6>
 
       <P>
         MEPP, su contenido y esta política de privacidad están sujetos a las
@@ -210,7 +264,14 @@ const LocalizedPrivacy = () => {
         jurisdicción exclusiva para resolverla.
       </P>
 
-      <H6>7.4 Comunicaciones</H6>
+      <H6>8.4 Responsable de protección de datos</H6>
+
+      <P>
+        Para cualquier pregunta sobre la protección de su información personal
+        o para ejercer sus derechos, puede contactar a nuestro responsable:
+      </P>
+
+      <H6>8.5 Comunicaciones</H6>
 
       <P>
         Puede ponerse en contacto con nosotros utilizando los siguientes datos:

--- a/src/pages/privacy/fr.js
+++ b/src/pages/privacy/fr.js
@@ -138,14 +138,55 @@ const LocalizedPrivacy = () => {
         nous vous invitons à nous contacter.
       </P>
 
-      <H5>3. TECHNOLOGIES</H5>
+      <H6>2.4 Droit de suppression et d’anonymisation</H6>
+
+      <P>
+        Vous pouvez demander la suppression de votre compte et l’anonymisation
+        de vos renseignements personnels. Vos données d’identification (nom,
+        courriel) seront rendues irréversiblement anonymes. Les données de
+        session et d’exercice seront conservées sous forme dé-identifiée à des
+        fins de recherche scientifique. Pour exercer ce droit, contactez votre
+        clinicien ou notre responsable de la protection des renseignements
+        personnels aux coordonnées indiquées ci-dessous.
+      </P>
+
+      <H6>2.5 Droit à la portabilité</H6>
+
+      <P>
+        Vous pouvez demander à recevoir vos renseignements personnels dans un
+        format structuré et couramment utilisé. Pour exercer ce droit,
+        contactez-nous aux coordonnées indiquées ci-dessous.
+      </P>
+
+      <H6>2.6 Finalités détaillées</H6>
+
+      <P>
+        Les renseignements personnels sont collectés et traités pour les
+        finalités suivantes :
+      </P>
+      <UL>
+        <LI>la création et la gestion de votre compte;</LI>
+        <LI>la personnalisation de vos exercices de rééducation;</LI>
+        <LI>le suivi de votre progression par votre clinicien;</LI>
+        <LI>la recherche scientifique sous forme dé-identifiée;</LI>
+        <LI>l’amélioration de MEPP et des approches de rééducation.</LI>
+      </UL>
+
+      <H5>3. TECHNOLOGIES ET COOKIES</H5>
 
       <P>
         Certaines technologies de MEPP sont liées aux renseignements généraux de
         votre appareil afin d’assurer la cohérence et la sécurité de votre
         session. Ces technologies sont requises pour que MEPP fonctionne
         correctement, et seront automatiquement supprimées si vous supprimez
-        MEPP. N’hésitez pas à communiquer avec nous pour toute question.
+        MEPP.
+      </P>
+
+      <P>
+        MEPP utilise des cookies strictement nécessaires au fonctionnement de
+        l’application (session, authentification). Aucun cookie de pistage ou
+        publicitaire n’est utilisé. Vous pouvez gérer vos préférences de cookies
+        via la bannière de consentement affichée lors de votre première visite.
       </P>
 
       <H5>4. MESURES DE SÉCURITÉ</H5>
@@ -164,14 +205,27 @@ const LocalizedPrivacy = () => {
         l’objet d’une interception de données ou autre événement incontrôlable.
       </P>
 
-      <H5>5. QUESTIONS</H5>
+      <H5>5. CADRE JURIDIQUE ET PLAINTES</H5>
+
+      <P>
+        MEPP est conforme à la Loi sur la protection des renseignements
+        personnels dans le secteur privé (Loi 25) du Québec. Si vous estimez que
+        vos droits ne sont pas respectés, vous pouvez déposer une plainte auprès
+        de la Commission d&apos;accès à l&apos;information du Québec (CAI) à l&apos;adresse
+        suivante&nbsp;:{' '}
+        <a href="https://www.cai.gouv.qc.ca" target="_blank" rel="noopener noreferrer">
+          www.cai.gouv.qc.ca
+        </a>.
+      </P>
+
+      <H5>6. QUESTIONS</H5>
 
       <P>
         Vous pouvez communiquer avec nous si vous avez des questions en lien
         avec nos pratiques de vie privée.
       </P>
 
-      <H5>6. HYPERLIENS</H5>
+      <H5>7. HYPERLIENS</H5>
 
       <P>
         MEPP et son contenu incluent des liens vers d’autres ressources. Ces
@@ -190,9 +244,9 @@ const LocalizedPrivacy = () => {
         avec celles-ci. La décision de consulter ces hyperliens vous revient.
       </P>
 
-      <H5>7. AUTRES TERMES</H5>
+      <H5>8. AUTRES TERMES</H5>
 
-      <H6>7.1 Accord complet</H6>
+      <H6>8.1 Accord complet</H6>
 
       <P>
         Cette politique de vie privée constitue, avec les conditions
@@ -201,7 +255,7 @@ const LocalizedPrivacy = () => {
         politique sont téléchargeables sur le site Internet de MEPP.
       </P>
 
-      <H6>7.2 Modifications</H6>
+      <H6>8.2 Modifications</H6>
 
       <P>
         Nous pouvons modifier cette politique de vie privée. Ces modifications
@@ -212,7 +266,7 @@ const LocalizedPrivacy = () => {
         appareil avant que ces changements n’entrent en vigueur.
       </P>
 
-      <H6>7.3 Lois applicables et disputes</H6>
+      <H6>8.3 Lois applicables et disputes</H6>
 
       <P>
         MEPP, son contenu et cette politique de vie privée sont sujets aux lois
@@ -222,7 +276,15 @@ const LocalizedPrivacy = () => {
         la régler.
       </P>
 
-      <H6>7.4 Communications</H6>
+      <H6>8.4 Responsable de la protection des renseignements personnels</H6>
+
+      <P>
+        Pour toute question relative à la protection de vos renseignements
+        personnels ou pour exercer vos droits, vous pouvez contacter notre
+        responsable :
+      </P>
+
+      <H6>8.5 Communications</H6>
 
       <P>Vous pouvez communiquer avec nous via les coordonnées suivantes :</P>
 

--- a/src/pages/privacy/it.js
+++ b/src/pages/privacy/it.js
@@ -125,7 +125,40 @@ const LocalizedPrivacy = () => {
         contattarci.
       </P>
 
-      <H5>3. TECNOLOGIE</H5>
+      <H6>2.4 Diritto alla cancellazione e all&apos;anonimizzazione</H6>
+
+      <P>
+        Potete richiedere la cancellazione del vostro account e
+        l&apos;anonimizzazione dei vostri dati personali. I vostri dati
+        identificativi (nome, email) saranno resi irreversibilmente anonimi. I
+        dati di sessione e di esercizio saranno conservati in forma
+        de-identificata a fini di ricerca scientifica. Per esercitare questo
+        diritto, contattate il vostro clinico o il nostro responsabile della
+        protezione dei dati ai recapiti indicati di seguito.
+      </P>
+
+      <H6>2.5 Diritto alla portabilità dei dati</H6>
+
+      <P>
+        Potete richiedere di ricevere i vostri dati personali in un formato
+        strutturato e di uso comune. Per esercitare questo diritto, contattateci
+        ai recapiti indicati di seguito.
+      </P>
+
+      <H6>2.6 Finalità dettagliate</H6>
+
+      <P>
+        I dati personali sono raccolti e trattati per le seguenti finalità:
+      </P>
+      <UL>
+        <LI>la creazione e la gestione del vostro account;</LI>
+        <LI>la personalizzazione dei vostri esercizi di riabilitazione;</LI>
+        <LI>il monitoraggio dei vostri progressi da parte del clinico;</LI>
+        <LI>la ricerca scientifica in forma de-identificata;</LI>
+        <LI>il miglioramento di MEPP e degli approcci riabilitativi.</LI>
+      </UL>
+
+      <H5>3. TECNOLOGIE E COOKIE</H5>
 
       <P>
         Alcune tecnologie di MEPP sono collegate a informazioni generali sul
@@ -133,6 +166,14 @@ const LocalizedPrivacy = () => {
         Queste tecnologie sono necessarie affinché MEPP funzioni correttamente e
         saranno eliminate automaticamente se disinstallate MEPP. Non esitate a
         contattarci per qualsiasi domanda.
+      </P>
+
+      <P>
+        MEPP utilizza cookie strettamente necessari al funzionamento
+        dell&apos;applicazione (sessione, autenticazione). Non vengono utilizzati
+        cookie di tracciamento o pubblicitari. Potete gestire le vostre
+        preferenze sui cookie tramite il banner di consenso visualizzato alla
+        vostra prima visita.
       </P>
 
       <H5>4. MISURE DI SICUREZZA</H5>
@@ -150,13 +191,25 @@ const LocalizedPrivacy = () => {
         soggetto a intercettazioni di dati o altri eventi incontrollabili.
       </P>
 
-      <H5>5. DOMANDE</H5>
+      <H5>5. QUADRO GIURIDICO E RECLAMI</H5>
+
+      <P>
+        MEPP è conforme alla Legge sulla protezione delle informazioni personali
+        nel settore privato (Legge 25) del Quebec. Se ritenete che i vostri
+        diritti non siano rispettati, potete presentare un reclamo alla
+        Commission d&apos;accès à l&apos;information du Québec (CAI):{' '}
+        <a href="https://www.cai.gouv.qc.ca" target="_blank" rel="noopener noreferrer">
+          www.cai.gouv.qc.ca
+        </a>.
+      </P>
+
+      <H5>6. DOMANDE</H5>
 
       <P>
         Potete contattarci se avete domande sulle nostre pratiche di privacy.
       </P>
 
-      <H5>6. COLLEGAMENTI IPERTESTUALI</H5>
+      <H5>7. COLLEGAMENTI IPERTESTUALI</H5>
 
       <P>
         MEPP e i suoi contenuti includono collegamenti a risorse esterne. Questi
@@ -175,9 +228,9 @@ const LocalizedPrivacy = () => {
         Spetta a voi decidere di consultare questi collegamenti ipertestuali.
       </P>
 
-      <H5>7. ALTRI TERMINI</H5>
+      <H5>8. ALTRI TERMINI</H5>
 
-      <H6>7.1 Accordo completo</H6>
+      <H6>8.1 Accordo completo</H6>
 
       <P>
         Questa politica sulla privacy costituisce, insieme ai termini d’uso,
@@ -186,7 +239,7 @@ const LocalizedPrivacy = () => {
         disponibili per il download sul sito web di MEPP.
       </P>
 
-      <H6>7.2 Modifiche</H6>
+      <H6>8.2 Modifiche</H6>
 
       <P>
         Possiamo modificare questa politica sulla privacy. Queste modifiche vi
@@ -197,7 +250,7 @@ const LocalizedPrivacy = () => {
         modifiche abbiano effetto.
       </P>
 
-      <H6>7.3 Leggi applicabili e controversie</H6>
+      <H6>8.3 Leggi applicabili e controversie</H6>
 
       <P>
         MEPP, i suoi contenuti e questa politica sulla privacy sono soggetti
@@ -207,7 +260,14 @@ const LocalizedPrivacy = () => {
         giurisdizione esclusiva per risolverla.
       </P>
 
-      <H6>7.4 Comunicazioni</H6>
+      <H6>8.4 Responsabile della protezione dei dati</H6>
+
+      <P>
+        Per qualsiasi domanda sulla protezione dei vostri dati personali o per
+        esercitare i vostri diritti, potete contattare il nostro responsabile:
+      </P>
+
+      <H6>8.5 Comunicazioni</H6>
 
       <P>Potete contattarci utilizzando i seguenti dettagli:</P>
 

--- a/src/pages/privacy/pt.js
+++ b/src/pages/privacy/pt.js
@@ -126,7 +126,41 @@ const LocalizedPrivacy = () => {
         conosco.
       </P>
 
-      <H5>3. TECNOLOGIAS</H5>
+      <H6>2.4 Direito à eliminação e anonimização</H6>
+
+      <P>
+        Pode solicitar a eliminação da sua conta e a anonimização das suas
+        informações pessoais. Os seus dados de identificação (nome, email)
+        serão anonimizados de forma irreversível. Os dados de sessão e
+        exercícios serão conservados de forma desidentificada para fins de
+        investigação científica. Para exercer este direito, contacte o seu
+        clínico ou o nosso responsável pela proteção de dados nos contactos
+        indicados abaixo.
+      </P>
+
+      <H6>2.5 Direito à portabilidade dos dados</H6>
+
+      <P>
+        Pode solicitar receber as suas informações pessoais num formato
+        estruturado e de uso comum. Para exercer este direito, contacte-nos
+        nos contactos indicados abaixo.
+      </P>
+
+      <H6>2.6 Finalidades detalhadas</H6>
+
+      <P>
+        As informações pessoais são recolhidas e tratadas para as seguintes
+        finalidades:
+      </P>
+      <UL>
+        <LI>a criação e gestão da sua conta;</LI>
+        <LI>a personalização dos seus exercícios de reabilitação;</LI>
+        <LI>o acompanhamento do seu progresso pelo seu clínico;</LI>
+        <LI>a investigação científica de forma desidentificada;</LI>
+        <LI>a melhoria do MEPP e das abordagens de reabilitação.</LI>
+      </UL>
+
+      <H5>3. TECNOLOGIAS E COOKIES</H5>
 
       <P>
         Certas tecnologias do MEPP estão vinculadas a informações gerais sobre
@@ -134,6 +168,14 @@ const LocalizedPrivacy = () => {
         Essas tecnologias são necessárias para que o MEPP funcione corretamente
         e serão excluídas automaticamente se você desinstalar o MEPP. Não hesite
         em nos contatar caso tenha alguma dúvida.
+      </P>
+
+      <P>
+        O MEPP utiliza cookies estritamente necessários ao funcionamento da
+        aplicação (sessão, autenticação). Não são utilizados cookies de
+        rastreamento ou publicitários. Pode gerir as suas preferências de
+        cookies através do banner de consentimento apresentado na sua primeira
+        visita.
       </P>
 
       <H5>4. MEDIDAS DE SEGURANÇA</H5>
@@ -151,14 +193,26 @@ const LocalizedPrivacy = () => {
         interceptação de dados ou outros eventos fora de controle.
       </P>
 
-      <H5>5. PERGUNTAS</H5>
+      <H5>5. ENQUADRAMENTO JURÍDICO E RECLAMAÇÕES</H5>
+
+      <P>
+        O MEPP está em conformidade com a Lei de proteção de informações
+        pessoais no setor privado (Lei 25) do Quebec. Se considerar que os seus
+        direitos não estão a ser respeitados, pode apresentar uma reclamação
+        junto da Commission d&apos;accès à l&apos;information du Québec (CAI):{' '}
+        <a href="https://www.cai.gouv.qc.ca" target="_blank" rel="noopener noreferrer">
+          www.cai.gouv.qc.ca
+        </a>.
+      </P>
+
+      <H5>6. PERGUNTAS</H5>
 
       <P>
         Você pode entrar em contato conosco caso tenha dúvidas sobre nossas
         práticas de privacidade.
       </P>
 
-      <H5>6. HIPERLINKS</H5>
+      <H5>7. HIPERLINKS</H5>
 
       <P>
         O MEPP e seu conteúdo incluem links para outros recursos. Esses
@@ -177,9 +231,9 @@ const LocalizedPrivacy = () => {
         relação a eles. Cabe a você decidir consultar esses hiperlinks.
       </P>
 
-      <H5>7. OUTROS TERMOS</H5>
+      <H5>8. OUTROS TERMOS</H5>
 
-      <H6>7.1 Acordo completo</H6>
+      <H6>8.1 Acordo completo</H6>
 
       <P>
         Esta política de privacidade constitui, junto com os termos de uso, o
@@ -188,7 +242,7 @@ const LocalizedPrivacy = () => {
         download no site do MEPP.
       </P>
 
-      <H6>7.2 Modificações</H6>
+      <H6>8.2 Modificações</H6>
 
       <P>
         Podemos modificar esta política de privacidade. Essas alterações serão
@@ -198,7 +252,7 @@ const LocalizedPrivacy = () => {
         ou desinstalar o aplicativo antes que essas alterações entrem em vigor.
       </P>
 
-      <H6>7.3 Leis aplicáveis e disputas</H6>
+      <H6>8.3 Leis aplicáveis e disputas</H6>
 
       <P>
         O MEPP, seu conteúdo e esta política de privacidade estão sujeitos às
@@ -208,7 +262,14 @@ const LocalizedPrivacy = () => {
         resolvê-la.
       </P>
 
-      <H6>7.4 Comunicações</H6>
+      <H6>8.4 Responsável pela proteção de dados</H6>
+
+      <P>
+        Para qualquer questão sobre a proteção das suas informações pessoais
+        ou para exercer os seus direitos, pode contactar o nosso responsável:
+      </P>
+
+      <H6>8.5 Comunicações</H6>
 
       <P>Você pode entrar em contato conosco usando os seguintes detalhes:</P>
 


### PR DESCRIPTION
## Summary
- Add right to deletion/anonymization (section 2.4)
- Add right to data portability (section 2.5)
- Add detailed purposes (section 2.6)
- Add cookie policy to Technologies section
- Add legal framework and CAI complaint procedure (section 5)
- Add privacy officer section (section 8.4)
- Updated in all 6 languages: FR, EN, ES, DE, IT, PT
- Renumbered sections accordingly

## Test plan
- [x] ESLint passes (`npm run lint`)
- [x] Visual verification of all 6 language pages
- [x] Review content accuracy with Sarah Martineau
- [x] Verify privacy officer contact details (placeholder)