### PR TITLE
feat: require MFA for every account, not just staff

### DIFF
--- a/mepp/api/services/mfa.py
+++ b/mepp/api/services/mfa.py
@@ -57,12 +57,10 @@ def requires_mfa(user) -> bool:
     """
     Return True if this user must complete an MFA step to obtain a token.
 
-    Patients (non-staff) bypass MFA. Staff and superusers are gated by the
-    MFA_REQUIRED_FOR_STAFF flag.
+    All authenticated users — patients, clinicians, admins, superusers — are
+    gated by the MFA_REQUIRED flag.
     """
-    if not getattr(settings, 'MFA_REQUIRED_FOR_STAFF', True):
-        return False
-    return bool(user.is_staff or user.is_superuser)
+    return bool(getattr(settings, 'MFA_REQUIRED', True))
 
 
 def _hash_code(code: str) -> str:

--- a/mepp/api/tests/api/v1/test_api_mfa.py
+++ b/mepp/api/tests/api/v1/test_api_mfa.py
@@ -35,8 +35,7 @@ from . import BaseV1TestCase
 
 class MFALoginTestCase(BaseV1TestCase):
     """
-    Two-step login for staff users (clinicians, admins).
-    Patients keep the one-step flow.
+    Two-step login for every user — patients, clinicians, admins, superusers.
     """
 
     def _post_credentials(self, username, language=None):
@@ -48,13 +47,18 @@ class MFALoginTestCase(BaseV1TestCase):
             data=data,
         )
 
-    def test_patient_login_bypasses_mfa(self):
+    def test_patient_login_returns_mfa_challenge(self):
         response = self._post_credentials(self.patient_john.username)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertNotIn('mfa_required', response.data)
-        self.assertIn('token', response.data)
-        self.assertEqual(MFAChallenge.objects.count(), 0)
-        self.assertEqual(len(mail.outbox), 0)
+        self.assertTrue(response.data['mfa_required'])
+        self.assertIn('challenge_id', response.data)
+        self.assertIn('expires_at', response.data)
+        self.assertNotIn('token', response.data)
+        self.assertEqual(
+            MFAChallenge.objects.filter(user=self.patient_john).count(), 1,
+        )
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn(self.patient_john.email, mail.outbox[0].to)
 
     def test_clinician_login_returns_mfa_challenge(self):
         response = self._post_credentials(self.john.username)

--- a/mepp/settings/base.py
+++ b/mepp/settings/base.py
@@ -167,12 +167,12 @@ HTTP_HOST = os.environ.get('HTTP_HOST', 'https://mirroreffectplus.org')
 # must not enable re-identification.
 RESEARCH_DEID_SALT = os.environ.get('RESEARCH_DEID_SALT')
 
-# Multi-factor authentication (email OTP for staff/admin accounts).
-# MFA_REQUIRED_FOR_STAFF can be flipped via env without redeploying — useful
-# if a clinician account ends up with an unreachable mailbox and needs
-# emergency access while we fix it.
-MFA_REQUIRED_FOR_STAFF = (
-    os.environ.get('MFA_REQUIRED_FOR_STAFF', 'true').strip().lower() == 'true'
+# Multi-factor authentication (email OTP for all user accounts).
+# MFA_REQUIRED can be flipped via env without redeploying — useful if a user
+# account ends up with an unreachable mailbox and needs emergency access while
+# we fix it.
+MFA_REQUIRED = (
+    os.environ.get('MFA_REQUIRED', 'true').strip().lower() == 'true'
 )
 MFA_CODE_LENGTH = 6
 MFA_CODE_TTL_SECONDS = 5 * 60  # 5 minutes


### PR DESCRIPTION
## Summary

Extends the email-OTP two-step login to patients. Previously, only clinicians, admins, and superusers had to confirm a 6-digit code; patients bypassed MFA entirely. After this PR every authenticated session goes through the same challenge.

- `requires_mfa()` no longer branches on `is_staff` / `is_superuser`
- Setting renamed `MFA_REQUIRED_FOR_STAFF` → `MFA_REQUIRED` (env var + Django setting) so the name matches its new scope
- The emergency-disable escape hatch is preserved (default: `true`)
- Patient test renamed from `_bypasses_mfa` to `_returns_mfa_challenge`

No frontend changes needed — `MfaForm` / `authProvider` / `Login` were already driven by the backend's `mfa_required` flag, with no client-side role gate.

## Deploy note (IMPORTANT)

If `MFA_REQUIRED_FOR_STAFF=...` is set in `~/repos/mepp-secrets/` on staging or production, rename it to `MFA_REQUIRED=` before redeploying. Otherwise the explicit override is lost and the default (`true`, MFA on) applies — same outcome in practice unless the value was `false` for emergency access.

## UX impact

Patients (potentially elderly / in rehab) will now have to fetch a 6-digit code from their email on every login. The 5-minute TTL and 5-attempt lockout from the original MFA work apply unchanged.

## Test plan

- [x] Unit/integration tests: 146 passed locally (`pipenv run pytest`)
- [ ] Smoke test on staging: patient login → email arrives → enter code → token issued
- [ ] Smoke test on staging: clinician login still works (regression)
- [ ] Smoke test on staging: wrong code increments attempts, locks after 5
- [ ] Confirm prod `mepp-secrets` env var is renamed before prod deploy